### PR TITLE
Fix tag default cardinalities

### DIFF
--- a/cmd/inch/main.go
+++ b/cmd/inch/main.go
@@ -86,7 +86,11 @@ func (m *Main) ParseFlags(args []string) error {
 	}
 
 	// Parse tag cardinalities.
-	for _, s := range strings.Split(*tags, ",") {
+	for i, s := range strings.Split(*tags, ",") {
+		if i == 0 {
+			// We're overriding default tag cardinalities
+			m.inch.Tags = []int{}
+		}
 		v, err := strconv.Atoi(s)
 		if err != nil {
 			return fmt.Errorf("cannot parse tag cardinality: %s", s)

--- a/cmd/inch/main.go
+++ b/cmd/inch/main.go
@@ -86,11 +86,8 @@ func (m *Main) ParseFlags(args []string) error {
 	}
 
 	// Parse tag cardinalities.
-	for i, s := range strings.Split(*tags, ",") {
-		if i == 0 {
-			// We're overriding default tag cardinalities
-			m.inch.Tags = []int{}
-		}
+	m.inch.Tags = []int{}
+	for _, s := range strings.Split(*tags, ",") {
 		v, err := strconv.Atoi(s)
 		if err != nil {
 			return fmt.Errorf("cannot parse tag cardinality: %s", s)


### PR DESCRIPTION
Fixes a recent bug where the default tag cardinalities `[]int{10,10,10}` were not removed when specifying custom cardinalities with the `-t` flag.