### PR TITLE
Allow a context to be passed to Run

### DIFF
--- a/cmd/inch/main.go
+++ b/cmd/inch/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -30,7 +31,7 @@ func main() {
 	}
 
 	// run inch
-	if err := m.inch.Run(); err != nil {
+	if err := m.inch.Run(context.Background()); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/inch.go
+++ b/inch.go
@@ -155,14 +155,14 @@ func (s *Simulator) Validate() error {
 }
 
 // Run executes the program.
-func (s *Simulator) Run() error {
+func (s *Simulator) Run(ctx context.Context) error {
 	// check valid settings before starting
 	err := s.Validate()
 	if err != nil {
 		return err
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	// Print settings.


### PR DESCRIPTION
If you wanted to do any signal catching so it could shut down properly, this could make it work better. It will also be useful in gigawatt.