### PR TITLE
Add custom field key prefix

### DIFF
--- a/cmd/inch/main.go
+++ b/cmd/inch/main.go
@@ -75,6 +75,7 @@ func (m *Main) ParseFlags(args []string) error {
 	fs.IntVar(&m.inch.Measurements, "m", 1, "Measurements")
 	tags := fs.String("t", "10,10,10", "Tag cardinality")
 	fs.IntVar(&m.inch.PointsPerSeries, "p", 100, "Points per series")
+	fs.StringVar(&m.inch.FieldPrefix, "field-prefix", "v0", "Field key prefix")
 	fs.IntVar(&m.inch.FieldsPerPoint, "f", 1, "Fields per point")
 	fs.IntVar(&m.inch.BatchSize, "b", 5000, "Batch size")
 	fs.StringVar(&m.inch.Database, "db", "stress", "Database to write to")

--- a/inch.go
+++ b/inch.go
@@ -90,6 +90,7 @@ type Simulator struct {
 	VHosts           uint64 // Simulate multiple virtual hosts
 	PointsPerSeries  int
 	FieldsPerPoint   int
+	FieldPrefix      string
 	BatchSize        int
 	TargetMaxLatency time.Duration
 	Gzip             bool
@@ -123,6 +124,7 @@ func NewSimulator() *Simulator {
 		VHosts:          0,
 		PointsPerSeries: 100,
 		FieldsPerPoint:  1,
+		FieldPrefix:     "v0",
 		BatchSize:       5000,
 		Database:        "db",
 		ShardDuration:   "7d",
@@ -330,7 +332,13 @@ func (s *Simulator) generateBatches() <-chan []byte {
 			if i < s.FieldsPerPoint-1 {
 				delim = ","
 			}
-			fields = append(fields, []byte(fmt.Sprintf("v%d=1%s", i, delim))...)
+
+			// First field doesn't have a number incremented.
+			pair := fmt.Sprintf("%s=1%s", s.FieldPrefix, delim)
+			if i > 0 {
+				pair = fmt.Sprintf("%s%d=1%s", s.FieldPrefix, i, delim)
+			}
+			fields = append(fields, []byte(pair)...)
 		}
 
 		// Size internal buffer to consider mx+tags+ +fields.


### PR DESCRIPTION
This PR adds the ability to specify the prefix of field keys written by inch.

By default `inch` will continue to use `v0` as the first field key, and, if the `-f` flag specifies to write multiple fields per point, they will be written as `v0=1,v01=1,v02=1....v0N=1`.

Users who are only interesting in writing a single field per point with a specific name, e.g., `value` or `temp` can do so by using the `field-prefix` flag as follows:

```
$ inch -field-prefix value
```

That will then ensure that all points are written with the `value=1` field. Without any further flags specifying the tag set cardinality, they would look like:

```
m0,tag0=value9,tag1=value8,tag2=value9 value=1
m0,tag0=value9,tag1=value9,tag2=value0 value=1
m0,tag0=value9,tag1=value9,tag2=value1 value=1
m0,tag0=value9,tag1=value9,tag2=value2 value=1
m0,tag0=value9,tag1=value9,tag2=value3 value=1
m0,tag0=value9,tag1=value9,tag2=value4 value=1
...
...
...
```

