### PR TITLE
chore: InfluxDB 2.0 support

### DIFF
--- a/cmd/inch/main.go
+++ b/cmd/inch/main.go
@@ -60,6 +60,8 @@ func (m *Main) ParseFlags(args []string) error {
 
 	fs := flag.NewFlagSet("inch", flag.ContinueOnError)
 	fs.BoolVar(&m.inch.Verbose, "v", false, "Verbose")
+	fs.BoolVar(&m.inch.V2, "v2", false, "Writing into InfluxDB 2.0")
+	fs.StringVar(&m.inch.Token, "token", "", "InfluxDB 2.0 Authorization token")
 	fs.StringVar(&m.inch.ReportHost, "report-host", "", "Host to send metrics")
 	fs.StringVar(&m.inch.ReportUser, "report-user", "", "User for Host to send metrics")
 	fs.StringVar(&m.inch.ReportPassword, "report-password", "", "Password Host to send metrics")


### PR DESCRIPTION
In order to be able to write into InfluxDB 2.0, authorization header needs to be set. Currently `inch` tool does not know if it is writing into InfluxDB v1 or InfluxDB v2. This PR adds 2 flags to be able to successfully write into InfluxDB v2.
If `-v2` is passed to the tool along with `-token` then authorization header will be set to:
`Authorization: Token <Token>`, where:
- v2: We are writing into InfluxDB v2
- token: authorization token for InfluxDB v2 