### PR TITLE
feat: add ability to not use the default setup from the command line

### DIFF
--- a/cmd/inch/main.go
+++ b/cmd/inch/main.go
@@ -87,9 +87,14 @@ func (m *Main) ParseFlags(args []string) error {
 	fs.DurationVar(&m.inch.Delay, "delay", 0, "Delay between writes")
 	fs.DurationVar(&m.inch.TargetMaxLatency, "target-latency", 0, "If set inch will attempt to adapt write delay to meet target")
 	fs.BoolVar(&m.inch.Gzip, "gzip", false, "Use gzip compression")
+	noSetup := *fs.Bool("no-setup", false, "Don't ping or set up tables/buckets on run (this is useful for load testing kapacitor)")
 
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+
+	if noSetup {
+		m.inch.SetupFn = func(s *inch.Simulator) error { return nil }
 	}
 
 	// Parse tag cardinalities.

--- a/inch.go
+++ b/inch.go
@@ -70,9 +70,9 @@ type Simulator struct {
 	WriteBatch func(s *Simulator, buf []byte) (statusCode int, body io.ReadCloser, err error)
 
 	// Decay factor used when weighting average latency returned by server.
-	alpha float64
-	V2	bool
-	Token 	string
+	alpha          float64
+	V2             bool
+	Token          string
 	Verbose        bool
 	ReportHost     string
 	ReportUser     string
@@ -676,7 +676,7 @@ var defaultSetupFn = func(s *Simulator) error {
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	if s.V2 == true {
-		req.Header.Set("Authorization", "Token " + s.Token)
+		req.Header.Set("Authorization", "Token "+s.Token)
 	}
 
 	if s.User != "" && s.Password != "" {
@@ -705,7 +705,7 @@ var defaultWriteBatch = func(s *Simulator, buf []byte) (statusCode int, body io.
 	}
 
 	if s.V2 == true {
-		req.Header.Set("Authorization", "Token " + s.Token)
+		req.Header.Set("Authorization", "Token "+s.Token)
 	}
 
 	var hostID uint64


### PR DESCRIPTION
This adds a no-setup flag which turns off inlfuxdb specific setup.  This is useful when load testing kapacitor.