### PR TITLE
feat: -randomize-fields argument

### DIFF
--- a/cmd/inch/main.go
+++ b/cmd/inch/main.go
@@ -79,6 +79,7 @@ func (m *Main) ParseFlags(args []string) error {
 	fs.IntVar(&m.inch.PointsPerSeries, "p", 100, "Points per series")
 	fs.StringVar(&m.inch.FieldPrefix, "field-prefix", "v0", "Field key prefix")
 	fs.IntVar(&m.inch.FieldsPerPoint, "f", 1, "Fields per point")
+	fs.BoolVar(&m.inch.RandomizeFields, "randomize-fields", false, "Randomize field values")
 	fs.IntVar(&m.inch.BatchSize, "b", 5000, "Batch size")
 	fs.StringVar(&m.inch.Database, "db", "stress", "Database to write to")
 	fs.StringVar(&m.inch.ShardDuration, "shard-duration", "7d", "Set shard duration (default 7d)")
@@ -109,15 +110,16 @@ func (m *Main) ParseFlags(args []string) error {
 
 	// Basic report tags.
 	m.inch.ReportTags = map[string]string{
-		"stress_tool":   "inch",
-		"t":             *tags,
-		"batch_size":    fmt.Sprint(m.inch.BatchSize),
-		"p":             fmt.Sprint(m.inch.PointsPerSeries),
-		"c":             fmt.Sprint(m.inch.Concurrency),
-		"m":             fmt.Sprint(m.inch.Measurements),
-		"f":             fmt.Sprint(m.inch.FieldsPerPoint),
-		"virtual_hosts": fmt.Sprint(m.inch.VHosts),
-		"sd":            m.inch.ShardDuration,
+		"stress_tool":      "inch",
+		"t":                *tags,
+		"batch_size":       fmt.Sprint(m.inch.BatchSize),
+		"p":                fmt.Sprint(m.inch.PointsPerSeries),
+		"c":                fmt.Sprint(m.inch.Concurrency),
+		"m":                fmt.Sprint(m.inch.Measurements),
+		"f":                fmt.Sprint(m.inch.FieldsPerPoint),
+		"randomize_fields": fmt.Sprint(m.inch.RandomizeFields),
+		"virtual_hosts":    fmt.Sprint(m.inch.VHosts),
+		"sd":               m.inch.ShardDuration,
 	}
 
 	// Parse report tags.

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/influxdata/inch
 
-go 1.12
+go 1.17
 
 require github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d


### PR DESCRIPTION
Instead of every field having the same value, which is ok for write performance but bad for running query tests on the generated data.