### PR TITLE
feat: allow one write per field for each point

### DIFF
--- a/cmd/inch/main.go
+++ b/cmd/inch/main.go
@@ -80,6 +80,7 @@ func (m *Main) ParseFlags(args []string) error {
 	fs.StringVar(&m.inch.FieldPrefix, "field-prefix", "v0", "Field key prefix")
 	fs.IntVar(&m.inch.FieldsPerPoint, "f", 1, "Fields per point")
 	fs.BoolVar(&m.inch.RandomizeFields, "randomize-fields", false, "Randomize field values")
+	fs.BoolVar(&m.inch.Multiwrite, "multiwrite", false, "One write per field instead of one write per point")
 	fs.IntVar(&m.inch.BatchSize, "b", 5000, "Batch size")
 	fs.StringVar(&m.inch.Database, "db", "stress", "Database to write to")
 	fs.StringVar(&m.inch.ShardDuration, "shard-duration", "7d", "Set shard duration (default 7d)")
@@ -120,6 +121,7 @@ func (m *Main) ParseFlags(args []string) error {
 		"randomize_fields": fmt.Sprint(m.inch.RandomizeFields),
 		"virtual_hosts":    fmt.Sprint(m.inch.VHosts),
 		"sd":               m.inch.ShardDuration,
+		"mw":               fmt.Sprint(m.inch.Multiwrite),
 	}
 
 	// Parse report tags.

--- a/inch.go
+++ b/inch.go
@@ -93,6 +93,7 @@ type Simulator struct {
 	PointsPerSeries  int
 	FieldsPerPoint   int
 	RandomizeFields  bool
+	Multiwrite       bool
 	FieldPrefix      string
 	BatchSize        int
 	TargetMaxLatency time.Duration
@@ -198,6 +199,7 @@ func (s *Simulator) Run(ctx context.Context) error {
 	fmt.Fprintf(s.Stdout, "Total points: %d\n", s.PointN())
 	fmt.Fprintf(s.Stdout, "Total fields per point: %d\n", s.FieldsPerPoint)
 	fmt.Fprintf(s.Stdout, "Randomized field values: %t\n", s.RandomizeFields)
+	fmt.Fprintf(s.Stdout, "Multiple writes per point: %t\n", s.Multiwrite)
 	fmt.Fprintf(s.Stdout, "Batch Size: %d\n", s.BatchSize)
 	fmt.Fprintf(s.Stdout, "Database: %s (Shard duration: %s)\n", s.Database, s.ShardDuration)
 	fmt.Fprintf(s.Stdout, "Write Consistency: %s\n", s.Consistency)
@@ -323,20 +325,19 @@ func (s *Simulator) BatchN() int {
 	return n
 }
 
-func (s *Simulator) makeField(val int) []byte {
-	var fields []byte
-	for i := 0; i < s.FieldsPerPoint; i++ {
-		var delim string
-		if i < s.FieldsPerPoint-1 {
-			delim = ","
-		}
+func (s *Simulator) makeField(val int) []string {
+	fields := make([]string, 0, s.FieldsPerPoint)
 
+	for i := 0; i < s.FieldsPerPoint; i++ {
 		// First field doesn't have a number incremented.
-		pair := fmt.Sprintf("%s=%d%s", s.FieldPrefix, val, delim)
+		pair := fmt.Sprintf("%s=%d", s.FieldPrefix, val)
 		if i > 0 {
-			pair = fmt.Sprintf("%s%d=%d%s", s.FieldPrefix, i, val, delim)
+			pair = fmt.Sprintf("%s%d=%d", s.FieldPrefix, i, val)
 		}
-		fields = append(fields, []byte(pair)...)
+		fields = append(fields, pair)
+	}
+	if !s.Multiwrite {
+		fields = []string{strings.Join(fields, ",")}
 	}
 	return fields
 }
@@ -349,14 +350,8 @@ func (s *Simulator) generateBatches() <-chan []byte {
 		values := make([]int, len(s.Tags))
 		lastWrittenTotal := s.WrittenN()
 
-		// For generating tag string.
-		var tags []byte
-
-		// For writing space between tags and field.
-		space := []byte(" ")
-
 		// Generate field strings
-		var fields [][]byte
+		var fields [][]string
 		maxFieldVal := 1
 		if s.RandomizeFields {
 			maxFieldVal = 10000
@@ -366,37 +361,45 @@ func (s *Simulator) generateBatches() <-chan []byte {
 		}
 
 		// Size internal buffer to consider mx+tags+ +fields.
-		buf := bytes.NewBuffer(make([]byte, 0, 2+len(tags)+1+len(fields)))
+		buf := bytes.NewBuffer(make([]byte, 0, 2+len(values)+1+len(fields)))
 
 		// Write points.
 		var lastMN int
 		lastM := []byte("m0")
 		fieldRandomize := rand.New(rand.NewSource(1234))
+		var tags []byte
+		var writesPerPoint = 1
+
+		if s.Multiwrite {
+			writesPerPoint = s.FieldsPerPoint
+		}
+
 		for i := 0; i < s.PointN(); i++ {
 			lastMN = i % s.Measurements
 			lastM = append(lastM[:1], []byte(strconv.Itoa(lastMN))...)
-			buf.Write(lastM) // Write measurement
-
+			tags = tags[:0] // Reset slice but use backing array.
 			for j, value := range values {
 				tags = append(tags, fmt.Sprintf(",tag%d=value%d", j, value)...)
 			}
-			buf.Write(tags)
-			tags = tags[:0] // Reset slice but use backing array.
 
-			buf.Write(space) // Write a space.
-
-			// Write all fields.
+			fieldValueIndex := 0
 			if s.RandomizeFields {
-				buf.Write(fields[fieldRandomize.Intn(maxFieldVal)])
-			} else {
-				buf.Write(fields[0])
+				fieldValueIndex = fieldRandomize.Intn(maxFieldVal)
 			}
 
+			var delta time.Duration
 			if s.timePerSeries != 0 {
-				delta := time.Duration(int64(lastWrittenTotal+i) * s.timePerSeries)
-				buf.Write([]byte(fmt.Sprintf(" %d\n", s.startTime.Add(delta).UnixNano())))
+				delta = time.Duration(int64(lastWrittenTotal+i) * s.timePerSeries)
 			} else {
-				fmt.Fprint(buf, "\n")
+				delta = time.Duration(int64(lastWrittenTotal + i))
+				if soFar := time.Since(s.startTime); delta < soFar {
+					delta = soFar
+				}
+			}
+			timestamp := s.startTime.Add(delta).UnixNano()
+
+			for f := 0; f < writesPerPoint; f++ {
+				s.formatWrites(buf, lastM, tags, fields[fieldValueIndex][f], timestamp)
 			}
 
 			// Increment next tag value.
@@ -409,7 +412,6 @@ func (s *Simulator) generateBatches() <-chan []byte {
 					continue
 				}
 			}
-
 			// Start new batch, if necessary.
 			if i > 0 && i%s.BatchSize == 0 {
 				ch <- copyBytes(buf.Bytes())
@@ -427,6 +429,16 @@ func (s *Simulator) generateBatches() <-chan []byte {
 	}()
 
 	return ch
+}
+
+var space []byte = []byte(" ")
+
+func (s *Simulator) formatWrites(buf *bytes.Buffer, measurement []byte, tags []byte, fieldValues string, timestamp int64) {
+	buf.Write(measurement) // Write measurement
+	buf.Write(tags)
+	buf.Write(space) // Write a space.
+	buf.WriteString(fieldValues)
+	buf.WriteString(fmt.Sprintf(" %d\n", timestamp))
 }
 
 // Vars is a subset of the data fields found at the /debug/vars endpoint.


### PR DESCRIPTION
Add a flag -multiwrite that spreads the writes
for each point out to one write per field,
while holding the timestamp and tags the same.
This permits testing the cost of handling a
write as distinct from the cost of saving a
point

Also fixes points in a series overwriting each
other because of identical timestamps.