### PR TITLE
Evaluate flag after argument parsing

### DIFF
--- a/cmd/inch/main.go
+++ b/cmd/inch/main.go
@@ -89,13 +89,13 @@ func (m *Main) ParseFlags(args []string) error {
 	fs.DurationVar(&m.inch.Delay, "delay", 0, "Delay between writes")
 	fs.DurationVar(&m.inch.TargetMaxLatency, "target-latency", 0, "If set inch will attempt to adapt write delay to meet target")
 	fs.BoolVar(&m.inch.Gzip, "gzip", false, "Use gzip compression")
-	noSetup := *fs.Bool("no-setup", false, "Don't ping or set up tables/buckets on run (this is useful for load testing kapacitor)")
+	noSetup := fs.Bool("no-setup", false, "Don't ping or set up tables/buckets on run (this is useful for load testing kapacitor)")
 
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
-	if noSetup {
+	if *noSetup {
 		m.inch.SetupFn = func(s *inch.Simulator) error { return nil }
 	}
 


### PR DESCRIPTION
`-no-setup` flag didn't work b/c pointer was evaluated before parsing the arguments. This PR fixes that by evaluating pointer after parsing.