### PR TITLE
feat: add -precision flag

### DIFF
--- a/cmd/inch/main.go
+++ b/cmd/inch/main.go
@@ -89,6 +89,7 @@ func (m *Main) ParseFlags(args []string) error {
 	fs.DurationVar(&m.inch.Delay, "delay", 0, "Delay between writes")
 	fs.DurationVar(&m.inch.TargetMaxLatency, "target-latency", 0, "If set inch will attempt to adapt write delay to meet target")
 	fs.BoolVar(&m.inch.Gzip, "gzip", false, "Use gzip compression")
+	fs.StringVar(&m.inch.Precision, "precision", "ns", "Precision of writes")
 	noSetup := fs.Bool("no-setup", false, "Don't ping or set up tables/buckets on run (this is useful for load testing kapacitor)")
 
 	if err := fs.Parse(args); err != nil {
@@ -122,6 +123,7 @@ func (m *Main) ParseFlags(args []string) error {
 		"virtual_hosts":    fmt.Sprint(m.inch.VHosts),
 		"sd":               m.inch.ShardDuration,
 		"mw":               fmt.Sprint(m.inch.OneFieldPerLine),
+		"precision":        m.inch.Precision,
 	}
 
 	// Parse report tags.


### PR DESCRIPTION
Add a precision flag that takes a standard precision
specifier for writes: "ns", "u", "ms", " s", "m", "h" 